### PR TITLE
修改剪切板hook为不随ime而hook

### DIFF
--- a/LRHook/LRHookFunc.cpp
+++ b/LRHook/LRHookFunc.cpp
@@ -18,6 +18,8 @@ void AttachFunctions()
 	//DetourAttach(&(PVOID&)OriginalGetWindowTextA, HookGetWindowTextA);
 	DetourAttach(&(PVOID&)OriginalCreateFontIndirectA, HookCreateFontIndirectA);
 	DetourAttach(&(PVOID&)OriginalTextOutA, HookTextOutA);
+	DetourAttach(&(PVOID&)OriginalGetClipboardData, HookGetClipboardData);
+	DetourAttach(&(PVOID&)OriginalSetClipboardData, HookSetClipboardData);
 	
 	Original.CodePage = OriginalGetACP();
 	if (settings.HookIME)
@@ -28,8 +30,6 @@ void AttachFunctions()
 			DetourAttach(&(PVOID&)OriginalImmGetCompositionStringA, HookImmGetCompositionStringA_WM);
 		DetourAttach(&(PVOID&)OriginalImmGetCandidateListA, HookImmGetCandidateListA);
 
-		DetourAttach(&(PVOID&)OriginalGetClipboardData, HookGetClipboardData);
-		DetourAttach(&(PVOID&)OriginalSetClipboardData, HookSetClipboardData);
 	}
 
 	//DetourAttach(&(PVOID&)OriginalShellExecuteA, HookShellExecuteA);
@@ -51,6 +51,8 @@ void DetachFunctions()
 	//DetourDetach(&(PVOID&)OriginalGetWindowTextA, HookGetWindowTextA);
 	DetourDetach(&(PVOID&)OriginalCreateFontIndirectA, HookCreateFontIndirectA);
 	DetourDetach(&(PVOID&)OriginalTextOutA, HookTextOutA);
+	DetourDetach(&(PVOID&)OriginalGetClipboardData, HookGetClipboardData);
+	DetourDetach(&(PVOID&)OriginalSetClipboardData, HookSetClipboardData);
 
 	if (settings.HookIME)
 	{
@@ -60,8 +62,6 @@ void DetachFunctions()
 			DetourDetach(&(PVOID&)OriginalImmGetCompositionStringA, HookImmGetCompositionStringA_WM);
 		DetourDetach(&(PVOID&)OriginalImmGetCandidateListA, HookImmGetCandidateListA);
 
-		DetourDetach(&(PVOID&)OriginalGetClipboardData, HookGetClipboardData);
-		DetourDetach(&(PVOID&)OriginalSetClipboardData, HookSetClipboardData);
 	}
 
 	//DetourDetach(&(PVOID&)OriginalShellExecuteA, HookShellExecuteA);


### PR DESCRIPTION
首先按道理剪切板是否需要hook应该和ime是没有关系的
经过枫之谷游戏的测试，将环境分为是否win7、是否32位游戏、是否hook输入法
测试结果为在以上环境中，hook剪切板后均未出现乱码情况，而在win7以上操作系统中，不hook剪切板会出现复制乱码情况
同时在32位游戏中，不hook ime的情况下，win7及win10操作系统均不乱码，hook后乱码
而64位游戏中，则是win7 hook ime后乱码，未hook时正常，win7以上则反过来，hook时正常，未hook时乱码





  | IME |   | 剪切板 |  
-- | -- | -- | -- | --
32位WIN7，HOOK | 乱码 | 不HOOK | 不乱码 | hook
32位WIN7，不HOOK | 不乱码 | | 不乱码
32位WIN7+，HOOK | 乱码 | 不HOOK | 不乱码 | hook
32位WIN7+，不HOOK | 不乱码 | | 乱码
64位WIN7，HOOK | 乱码 | 不HOOK | 不乱码 | hook
64位WIN7，不HOOK | 不乱码 | | 不乱码
64位WIN7+，HOOK | 不乱码 | hook | 不乱码 | hook
64位WIN7+，不HOOK | 乱码 | | 乱码

所以应当认为剪切板应当固定hook，而ime则根据情况hook