### PR TITLE
Replace method GetUserDefaultLocaleName and GetSystemDefaultLocaleName

### DIFF
--- a/LRCommonLibrary/LRCommonLibrary.cpp
+++ b/LRCommonLibrary/LRCommonLibrary.cpp
@@ -9,6 +9,7 @@ int LRConfigFileMap::WrtieConfigFileMap(LRProfile *profile)
 	SetEnvironmentVariableW(L"LRBIAS", (LPCWSTR)&profile->Bias);
 	SetEnvironmentVariableW(L"LRHookIME", (LPCWSTR)&profile->HookIME);
 	SetEnvironmentVariableW(L"LRHookLCID", (LPCWSTR)&profile->HookLCID);
+	SetEnvironmentVariableW(L"LRLocation", (LPCWSTR)&profile->Location);
 	return 0;
 }
 
@@ -19,5 +20,8 @@ int LRConfigFileMap::ReadConfigFileMap(LRProfile* profile)
 	GetEnvironmentVariableW(L"LRBIAS", (LPWSTR)&profile->Bias, sizeof(long));
 	GetEnvironmentVariableW(L"LRHookIME", (LPWSTR)&profile->HookIME,sizeof(int));
 	GetEnvironmentVariableW(L"LRHookLCID", (LPWSTR)&profile->HookLCID, sizeof(int));
+	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
+	GetEnvironmentVariableW(L"LRLocation", buffer, LOCALE_NAME_MAX_LENGTH);
+	profile->Location = buffer;
 	return 0;
 }

--- a/LRCommonLibrary/LRCommonLibrary.h
+++ b/LRCommonLibrary/LRCommonLibrary.h
@@ -14,6 +14,7 @@ struct LRProfile
 	long Bias;
 	int HookIME;
 	int HookLCID;
+	std::wstring Location;
 };
 
 const int BUF_SIZE = sizeof(LRProfile);

--- a/LRHook/LRHookFunc.cpp
+++ b/LRHook/LRHookFunc.cpp
@@ -18,6 +18,8 @@ void AttachFunctions()
 	DetourAttach(&(PVOID&)OriginalGetUserDefaultLangID, HookGetUserDefaultLangID);
 	DetourAttach(&(PVOID&)OriginalMultiByteToWideChar, HookMultiByteToWideChar);
 	DetourAttach(&(PVOID&)OriginalWideCharToMultiByte, HookWideCharToMultiByte);
+	DetourAttach(&(PVOID&)OriginalGetUserDefaultLocaleName, HookGetUserDefaultLocaleName);
+	DetourAttach(&(PVOID&)OriginalGetSystemDefaultLocaleName, HookGetSystemDefaultLocaleName);
 
 	DetourAttach(&(PVOID&)OriginalCreateWindowExA, HookCreateWindowExA);
 	DetourAttach(&(PVOID&)OriginalDefWindowProcA, HookDefWindowProcA);
@@ -103,6 +105,8 @@ void DetachFunctions()
 	DetourDetach(&(PVOID&)OriginalGetUserDefaultLangID, HookGetUserDefaultLangID);
 	DetourDetach(&(PVOID&)OriginalMultiByteToWideChar, HookMultiByteToWideChar);
 	DetourDetach(&(PVOID&)OriginalWideCharToMultiByte, HookWideCharToMultiByte);
+	DetourDetach(&(PVOID&)OriginalGetUserDefaultLocaleName, HookGetUserDefaultLocaleName);
+	DetourDetach(&(PVOID&)OriginalGetSystemDefaultLocaleName, HookGetSystemDefaultLocaleName);
 
 	DetourDetach(&(PVOID&)OriginalCreateWindowExA, HookCreateWindowExA);
 	DetourDetach(&(PVOID&)OriginalDefWindowProcA, HookDefWindowProcA);

--- a/LRHook/LRHookFunc.h
+++ b/LRHook/LRHookFunc.h
@@ -39,6 +39,17 @@ static LCID WINAPI HookGetSystemDefaultLCID(void) { return HookGetLocaleID(); }
 static LCID WINAPI HookGetUserDefaultLCID(void) { return HookGetLocaleID(); }
 static LANGID WINAPI HookGetSystemDefaultLangID(void) { return (LANGID)HookGetLocaleID(); }
 static LANGID WINAPI HookGetUserDefaultLangID(void) { return (LANGID)HookGetLocaleID(); }
+inline int WINAPI HookGetUserDefaultLocaleName(LPWSTR lpLocalName, int cchLocalName)
+{
+	wcscpy(lpLocalName, settings.Location.c_str() + '\0');
+	return settings.Location.length() + 1;
+}
+
+static int WINAPI HookGetSystemDefaultLocaleName(LPWSTR lpLocalName, int cchLocalName)
+{
+	wcscpy(lpLocalName, settings.Location.c_str() + '\0');
+	return settings.Location.length() + 1;
+}
 
 HWND WINAPI HookCreateWindowExA(
 	DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle,

--- a/LRHook/LROriginalFunc.h
+++ b/LRHook/LROriginalFunc.h
@@ -28,6 +28,14 @@ static int (WINAPI* OriginalWideCharToMultiByte)(
 	LPBOOL lpUsedDefaultChar
 	) = WideCharToMultiByte;
 
+static int (WINAPI* OriginalGetUserDefaultLocaleName)(
+	LPWSTR lpLocalName,
+	int cchLocalName) = GetUserDefaultLocaleName;
+
+static int (WINAPI* OriginalGetSystemDefaultLocaleName)(
+	LPWSTR lpLocalName,
+	int cchLocalName) = GetSystemDefaultLocaleName;
+
 static UINT(WINAPI* OriginalGetACP)(void) = GetACP;
 static UINT(WINAPI* OriginalGetOEMCP)(void) = GetOEMCP;
 static BOOL(WINAPI* OriginalGetCPInfo)(

--- a/LRProc/LRProc.cpp
+++ b/LRProc/LRProc.cpp
@@ -62,6 +62,13 @@ You can also run LREditor to use this applicaction.
 	beta.Bias = alpha->Bias; // Bias will become negative in HookGetTimeZoneInformation
 	beta.HookIME = alpha->HookIME;
 	beta.HookLCID = alpha->HookLCID;
+	// Convert managed System::String to unmanaged std::wstring
+	std::wstring wLocation;
+	const wchar_t* chars = (const wchar_t*)Marshal::StringToHGlobalUni(alpha->Location).ToPointer();
+	wLocation = chars;
+	Marshal::FreeHGlobal(System::IntPtr((void*)chars));
+	// Set name of Location
+	beta.Location = wLocation.c_str();
 
 	LRConfigFileMap filemap;
 	filemap.WrtieConfigFileMap(&beta);


### PR DESCRIPTION
Methods for Vista and more. Microsoft replace code lang by name lang since Vista. So they recommend to use these new methods (instead of LCID)
https://learn.microsoft.com/windows/win32/api/winnls/nf-winnls-getuserdefaultlocalename
https://learn.microsoft.com/windows/win32/api/winnls/nf-winnls-getsystemdefaultlocalename

Replace full lang name.

Not tested on a japanese or chinese Windows, but i put the language name in unicode string, so must work (only tested on "english US" and "french france" Windows).
