### PR TITLE
Register menu for executable files when the extension is ".EXE" in uppercase

### DIFF
--- a/LRSubMenu/LRSubMenu.cs
+++ b/LRSubMenu/LRSubMenu.cs
@@ -121,7 +121,7 @@ namespace LRSubMenus
 				var extension = Path.GetExtension(filepath);
 				if (LRConfig.FileType.Equals("exe"))
 				{
-					if (!extension.Equals(".exe"))
+					if (!extension.ToLower().Equals(".exe"))
 					{
 						return menu;
 					}


### PR DESCRIPTION
Sometimes, executable files may have the extension ".EXE".